### PR TITLE
Move MkDocs dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,29 @@
 
 ### Dependencies 
 
+This repository uses [uv] for project management. Dependency bounds are defined in [`pyproject.toml`]and the locked environment is specified in [`uv.lock`].
+
+```
+uv sync
 ```
 
+# Model/Analysis 
+
+This repository contains a single analysis script [`aviation.py`](aviation.py), which implements a simple model for global aviation. It outputs the required global fleet. 
+
+To execute the analysis script, run: 
+
+```
+uv run python aviation.py
 ```
 
 ### Documentation 
 
-This repository uses Mkdocs to generate a static documentation site. The contents of the site can be found in [`docs/`]
+This repository uses Mkdocs to generate a static documentation site. The contents of the site can be found in [`docs/`].
+
+To serve the site locally, run: 
+
+```
+uv run mkdocs serve
+```
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Dependencies 
 
-This repository uses [uv] for project management. Dependency bounds are defined in [`pyproject.toml`]and the locked environment is specified in [`uv.lock`].
+This repository uses [uv](https://docs.astral.sh/uv/) for project management. Dependency bounds are defined in [`pyproject.toml`](pyproject.toml) and the locked environment is specified in [`uv.lock`](uv.lock).
 
 ```
 uv sync
@@ -20,7 +20,7 @@ uv run python aviation.py
 
 ### Documentation 
 
-This repository uses Mkdocs to generate a static documentation site. The contents of the site can be found in [`docs/`].
+This repository uses Mkdocs to generate a static documentation site. The contents of the site can be found in [`docs/`](docs).
 
 To serve the site locally, run: 
 

--- a/aviation.py
+++ b/aviation.py
@@ -1,0 +1,11 @@
+# Simple model 
+
+# Constants
+days_per_year = 365.0
+passengers_per_year = 5_000_000_000.0
+flights_per_aircraft = 2.5
+seats_per_aircraft = 180.0
+
+passengers_per_day = passengers_per_year / days_per_year
+required_global_fleet = passengers_per_day / (seats_per_aircraft * flights_per_aircraft)
+print(f"{required_global_fleet =:.2f}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
+dependencies = []
+
+[dependency-groups]
+docs = [
     "mkdocs>=1.6.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -6,12 +6,16 @@ requires-python = ">=3.12"
 name = "aviation"
 version = "0.1.0"
 source = { virtual = "." }
-dependencies = [
+
+[package.dev-dependencies]
+docs = [
     { name = "mkdocs" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "mkdocs", specifier = ">=1.6.1" }]
+
+[package.metadata.requires-dev]
+docs = [{ name = "mkdocs", specifier = ">=1.6.1" }]
 
 [[package]]
 name = "click"


### PR DESCRIPTION
This PR moves the MkDocs dependency to a new `docs` dependency group and adds a `Model/Analysis` section to the `README.md` explaining how to execute the `aviation.py` script using uv. 